### PR TITLE
Tests running locally

### DIFF
--- a/configs/open5gs/mme.yaml.in
+++ b/configs/open5gs/mme.yaml.in
@@ -353,6 +353,7 @@ mme:
         services: [ MOUNTAIN_RESCUE, MARINE_GUARD, FIRE_BRIGADE, AMBULANCE, POLICE ]
         bcd: 115
     redis:
+      enabled: True
       addr: "127.0.0.1"
       port: 6379
       expire_time_sec: 3

--- a/lib/app/ogs-context.c
+++ b/lib/app/ogs-context.c
@@ -172,7 +172,7 @@ static void app_context_prepare(void)
 
     self.sockopt.no_delay = true;
 
-#define MAX_NUM_OF_UE               4069    /* Num of UEs */
+#define MAX_NUM_OF_UE               1024    /* Num of UEs */
 #define MAX_NUM_OF_PEER             64      /* Num of Peer */
 
     self.max.ue = MAX_NUM_OF_UE;

--- a/lib/proto/types.h
+++ b/lib/proto/types.h
@@ -28,7 +28,7 @@
 extern "C" {
 #endif /* __cplusplus */
 
-#define OGS_MAX_NUM_OF_SESS             8   /* Num of APN(Session) per UE */
+#define OGS_MAX_NUM_OF_SESS             4   /* Num of APN(Session) per UE */
 #define OGS_MAX_NUM_OF_BEARER           4   /* Num of Bearer per Session */
 #define OGS_BEARER_PER_UE               8   /* Num of Bearer per UE */
 #define OGS_MAX_NUM_OF_PACKET_BUFFER    64  /* Num of PacketBuffer per UE */

--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -1575,18 +1575,29 @@ int mme_context_parse_config(void)
                     ogs_yaml_iter_recurse(&mme_iter, &redis_iter);
 
                     while (ogs_yaml_iter_next(&redis_iter)) {
-                        const char *eir_key = ogs_yaml_iter_key(&redis_iter);
-                        ogs_assert(eir_key);
-                        if (!strcmp(eir_key, "addr")) {
+                        const char *redis_key = ogs_yaml_iter_key(&redis_iter);
+                        ogs_assert(redis_key);
+                        if (!strcmp(redis_key, "addr")) {
                             const char *redis_addr = ogs_yaml_iter_value(&redis_iter);
                             
                             strncpy(self.redis_config.address, redis_addr, 16);
-                        } else if (!strcmp(eir_key, "port")) {
+                        } else if (!strcmp(redis_key, "enabled")) {
+                            const char *c_redis_enabled = ogs_yaml_iter_value(&redis_iter);
+
+                            if (!strcmp("True", c_redis_enabled) || 
+                                !strcmp("true", c_redis_enabled)) {
+                                ogs_info("Redis functionality has been enabled");
+                                self.redis_config.enabled = true;
+                            }
+                            else {
+                                self.redis_config.enabled = false;
+                            }
+                        } else if (!strcmp(redis_key, "port")) {
                             const char *redis_port = ogs_yaml_iter_value(&redis_iter);
 
                             if (redis_port)
                                 self.redis_config.port = atoi(redis_port);
-                        } else if (!strcmp(eir_key, "expire_time_sec")) {
+                        } else if (!strcmp(redis_key, "expire_time_sec")) {
                             const char *redis_expire_time_sec = ogs_yaml_iter_value(&redis_iter);
 
                             if (redis_expire_time_sec)

--- a/src/mme/mme-context.h
+++ b/src/mme/mme-context.h
@@ -88,6 +88,7 @@ typedef struct {
 } emergency_number_list_item_t;
 
 typedef struct {
+    bool enabled;
     char address[16];
     unsigned port;
     unsigned expire_time_sec;

--- a/src/mme/mme-sm.c
+++ b/src/mme/mme-sm.c
@@ -237,7 +237,11 @@ void mme_state_operational(ogs_fsm_t *s, mme_event_t *e)
         ogs_assert(OGS_FSM_STATE(&enb->sm));
 
         rc = ogs_s1ap_decode(&s1ap_message, pkbuf);
-        bool is_dup = is_messgae_dup(pkbuf->data, pkbuf->len);
+
+        bool is_dup = false;
+        if (mme_self()->redis_config.enabled) {
+            is_dup = is_messgae_dup(pkbuf->data, pkbuf->len);
+        }
 
         /* If the message is a duplicate then
          * we pretend we never got a message */


### PR DESCRIPTION
Finally found out why the tests were failing. Looks like the increase of MAX_NUM_OF_UE from 1024 to 4069 causes blows out the memory allocation to a ridiculous number (337,499,136 Bytes) later on when its initialising everything, so I have changed it back to the original value of 1024 for the moment so we have passing tests. I have also changed OGS_MAX_NUM_OF_SESS back to 4 (from 8) for the same reason (although changing MAX_NUM_OF_UE back to 1024 solved the issue alone). I also kept getting annoying prints when trying to connect to redis when it wasnt set up correctly so I have added a check so ensure its enabled first before doing the duplicate message testing.

@nickvsnetworking 