### PR TITLE
Feature/enb cellid homenode prom

### DIFF
--- a/lib/metrics/context.h
+++ b/lib/metrics/context.h
@@ -101,7 +101,7 @@ ogs_metrics_inst_t *ogs_metrics_inst_new(
         unsigned int num_labels, const char **label_values);
 void ogs_metrics_inst_free(ogs_metrics_inst_t *inst);
 void ogs_metrics_inst_set(ogs_metrics_inst_t *inst, int val);
-void ogs_metrics_inst_set_with_label(ogs_metrics_inst_t *inst, char *label, int val);
+void ogs_metrics_inst_set_with_labels(ogs_metrics_inst_t *inst, const char **label_values, int val);
 void ogs_metrics_inst_reset(ogs_metrics_inst_t *inst);
 void ogs_metrics_inst_add(ogs_metrics_inst_t *inst, int val);
 static inline void ogs_metrics_inst_inc(ogs_metrics_inst_t *inst)

--- a/lib/metrics/prometheus/context.c
+++ b/lib/metrics/prometheus/context.c
@@ -491,11 +491,11 @@ void ogs_metrics_inst_set(ogs_metrics_inst_t *inst, int val)
     }
 }
 
-void ogs_metrics_inst_set_with_label(ogs_metrics_inst_t *inst, char *label, int val)
+void ogs_metrics_inst_set_with_labels(ogs_metrics_inst_t *inst, const char **label_values, int val)
 {
     switch (inst->spec->type) {
     case OGS_METRICS_METRIC_TYPE_GAUGE:
-        prom_gauge_set(inst->spec->prom, (double)val, (const char **)&label);
+        prom_gauge_set(inst->spec->prom, (double)val, (const char **)label_values);
         break;
     default:
         ogs_assert_if_reached();

--- a/lib/metrics/void/context.c
+++ b/lib/metrics/void/context.c
@@ -95,7 +95,7 @@ void ogs_metrics_inst_set(ogs_metrics_inst_t *inst, int val)
 {
 }
 
-void ogs_metrics_inst_set_with_label(ogs_metrics_inst_t *inst, char *label, int val)
+void ogs_metrics_inst_set_with_labels(ogs_metrics_inst_t *inst, const char **label_values, int val)
 {
 }
 

--- a/src/mme/esm-handler.c
+++ b/src/mme/esm-handler.c
@@ -161,6 +161,12 @@ int esm_handle_pdn_connectivity_request(mme_bearer_t *bearer,
 
         ogs_assert(OGS_OK ==
             mme_gtp_send_create_session_request(sess, create_action));
+
+        // todo
+        if (!strcmp("sos", sess->session->name)) {
+            mme_metrics_inst_global_inc(MME_METR_GLOB_GAUGE_EMERGENCY_BEARERS);
+        }
+
     } else {
         ogs_error("No APN");
         r = nas_eps_send_pdn_connectivity_reject(

--- a/src/mme/esm-handler.c
+++ b/src/mme/esm-handler.c
@@ -162,11 +162,9 @@ int esm_handle_pdn_connectivity_request(mme_bearer_t *bearer,
         ogs_assert(OGS_OK ==
             mme_gtp_send_create_session_request(sess, create_action));
 
-        // todo
         if (!strcmp("sos", sess->session->name)) {
             mme_metrics_inst_global_inc(MME_METR_GLOB_GAUGE_EMERGENCY_BEARERS);
         }
-
     } else {
         ogs_error("No APN");
         r = nas_eps_send_pdn_connectivity_reject(

--- a/src/mme/metrics.c
+++ b/src/mme/metrics.c
@@ -193,7 +193,6 @@ int mme_metrics_free_inst_local(void)
     return mme_metrics_free_inst(&mme_metrics_inst_local, _MME_METR_LOCAL_MAX);
 }
 
-// todo make these a generic ip-key whatever-value pair
 void mme_metrics_connected_enb_id_inc(mme_metric_type_local_t t, char* ip_address, char* cell_id)
 {
     ogs_metrics_inst_t *metrics = get_dynamically_initialised_metric(t, ip_address, cell_id);
@@ -208,7 +207,6 @@ void mme_metrics_connected_enb_id_inc(mme_metric_type_local_t t, char* ip_addres
     }
 }
 
-// todo change to add and remove or whatever to better indicate what it actually does
 void mme_metrics_connected_enb_id_dec(mme_metric_type_local_t t, char* ip_address, char* cell_id)
 {
     ogs_metrics_inst_t *metrics = get_dynamically_initialised_metric(t, ip_address, cell_id);

--- a/src/mme/metrics.c
+++ b/src/mme/metrics.c
@@ -60,6 +60,11 @@ mme_metrics_spec_def_t mme_metrics_spec_def_global[_MME_METR_GLOB_MAX] = {
     .name = "mme_session",
     .description = "MME Sessions",
 },
+[MME_METR_GLOB_GAUGE_EMERGENCY_BEARERS] = {
+    .type = OGS_METRICS_METRIC_TYPE_GAUGE,
+    .name = "emergency_bearers",
+    .description = "Number of emergency bearers connected",
+},
 };
 
 int mme_metrics_init_inst_global(void)
@@ -73,6 +78,11 @@ int mme_metrics_free_inst_global(void)
 }
 
 /* LOCAL */
+const char *labels_enb_id[] = {
+    "ip_address",
+    "cell_id",
+};
+
 const char *labels_enb[] = {
     "connected"
 };
@@ -88,7 +98,55 @@ mme_metrics_spec_def_t mme_metrics_spec_def_local[_MME_METR_LOCAL_MAX] = {
         .num_labels = OGS_ARRAY_SIZE(labels_enb),
         .labels = labels_enb,
 },
+[MME_METR_LOCAL_GAUGE_ENB_ID] = {
+        .type = OGS_METRICS_METRIC_TYPE_GAUGE,
+        .name = "enb_cell_id",
+        .description = "Connection status of eNB with eNB ID",
+        .num_labels = OGS_ARRAY_SIZE(labels_enb_id),
+        .labels = labels_enb_id,
+},
 };
+
+typedef struct mme_metric_key_local_s {
+    char* ip_address;
+    char* cell_id;
+    char* home_node_b_id;
+    mme_metric_type_local_t t;
+} mme_metric_key_local_t;
+
+ogs_hash_t *metrics_hash_local = NULL;   /* hash table for LOCAL labels */
+
+/* Gets an existing one or creates a new one and resturns it */
+static ogs_metrics_inst_t *get_dynamically_initialised_metric(mme_metric_type_local_t t, char* ip_address, char* cell_id)
+{
+    ogs_metrics_inst_t *metrics = NULL;
+    mme_metric_key_local_t *slice_key;
+
+    slice_key = ogs_calloc(1, sizeof(*slice_key));
+    ogs_assert(slice_key);
+
+    slice_key->ip_address = ip_address;
+    slice_key->cell_id = cell_id;
+    slice_key->t = t;
+
+    metrics = ogs_hash_get(metrics_hash_local,
+            slice_key, sizeof(*slice_key));
+
+    /* Create the metric if it doesn't already exist.
+     * If it does exist then we can just return that. */
+    if (!metrics) {
+        metrics = ogs_metrics_inst_new(mme_metrics_spec_local[t],
+                mme_metrics_spec_def_local[t].num_labels,
+                (const char *[]){ ip_address, cell_id });
+
+        ogs_assert(metrics);
+        ogs_hash_set(metrics_hash_local,
+                slice_key, sizeof(*slice_key), metrics);
+    } else {
+        ogs_free(slice_key);
+    }
+    return metrics;
+}
 
 void mme_metrics_connected_enb_inc(char *ip_address)
 {
@@ -98,7 +156,7 @@ void mme_metrics_connected_enb_inc(char *ip_address)
         ogs_metrics_inst_inc(mme_metrics_inst_local);
 
         // Set connected IP to 1
-        ogs_metrics_inst_set_with_label(mme_metrics_inst_local, ip_address, 1);
+        ogs_metrics_inst_set_with_labels(mme_metrics_inst_local, (const char *[]){ ip_address }, 1);
     } else {
         ogs_error("Failed to change eNB metrics as instance or ip address doesn't exist");
     }
@@ -112,7 +170,7 @@ void mme_metrics_connected_enb_dec(char *ip_address)
         ogs_metrics_inst_dec(mme_metrics_inst_local);
 
         // Set connected IP to 0
-        ogs_metrics_inst_set_with_label(mme_metrics_inst_local, ip_address, 0);
+        ogs_metrics_inst_set_with_labels(mme_metrics_inst_local, (const char *[]){ ip_address }, 0);
     } else {
         ogs_error("Failed to change eNB metrics as instance or ip address doesn't exist");
     }
@@ -135,6 +193,42 @@ int mme_metrics_free_inst_local(void)
     return mme_metrics_free_inst(&mme_metrics_inst_local, _MME_METR_LOCAL_MAX);
 }
 
+// todo make these a generic ip-key whatever-value pair
+void mme_metrics_connected_enb_id_inc(mme_metric_type_local_t t, char* ip_address, char* cell_id)
+{
+    ogs_metrics_inst_t *metrics = get_dynamically_initialised_metric(t, ip_address, cell_id);
+
+    if ((NULL != metrics) &&
+        (NULL != ip_address) &&
+        (NULL != cell_id))
+    {
+        ogs_metrics_inst_set_with_labels(metrics, (const char *[]){ ip_address, cell_id }, 1);
+    } else {
+        ogs_error("Failed to record eNB connection status metrics");
+    }
+}
+
+// todo change to add and remove or whatever to better indicate what it actually does
+void mme_metrics_connected_enb_id_dec(mme_metric_type_local_t t, char* ip_address, char* cell_id)
+{
+    ogs_metrics_inst_t *metrics = get_dynamically_initialised_metric(t, ip_address, cell_id);
+
+    if ((NULL != metrics) &&
+        (NULL != ip_address) &&
+        (NULL != cell_id))
+    {
+        ogs_metrics_inst_set_with_labels(metrics, (const char *[]){ ip_address, cell_id }, 0);
+    } else {
+        ogs_error("Failed to record eNB connection status metrics");
+    }
+}
+
+void mme_metrics_init_local(void)
+{
+    metrics_hash_local = ogs_hash_make();
+    ogs_assert(metrics_hash_local);
+}
+
 void mme_metrics_init(void)
 {
     ogs_metrics_context_t *ctx = ogs_metrics_self();
@@ -148,9 +242,28 @@ void mme_metrics_init(void)
 
     mme_metrics_init_inst_global();
     mme_metrics_init_inst_local();
+
+    mme_metrics_init_local();
 }
 
 void mme_metrics_final(void)
 {
+    if (metrics_hash_local) {
+        ogs_hash_index_t *hi;
+
+        for (hi = ogs_hash_first(metrics_hash_local); hi; hi = ogs_hash_next(hi)) {
+            mme_metric_key_local_t *key =
+                (mme_metric_key_local_t *)ogs_hash_this_key(hi);
+
+            ogs_hash_set(metrics_hash_local, key, sizeof(*key), NULL);
+
+            ogs_free(key);
+            /* don't free val (metric ifself) -
+             * it will be free'd by ogs_metrics_context_final() */
+            //ogs_free(val);
+        }
+        ogs_hash_destroy(metrics_hash_local);
+    }
+
     ogs_metrics_context_final();
 }

--- a/src/mme/metrics.h
+++ b/src/mme/metrics.h
@@ -11,6 +11,7 @@ extern "C" {
 typedef enum mme_metric_type_global_s {
     MME_METR_GLOB_GAUGE_ENB_UE,
     MME_METR_GLOB_GAUGE_MME_SESS,
+    MME_METR_GLOB_GAUGE_EMERGENCY_BEARERS,
     _MME_METR_GLOB_MAX,
 } mme_metric_type_global_t;
 extern ogs_metrics_inst_t *mme_metrics_inst_global[_MME_METR_GLOB_MAX];
@@ -29,14 +30,19 @@ static inline void mme_metrics_inst_global_dec(mme_metric_type_global_t t)
 
 typedef enum mme_metric_type_local_s {
     MME_METR_LOCAL_GAUGE_ENB,
+    MME_METR_LOCAL_GAUGE_ENB_ID,
     _MME_METR_LOCAL_MAX,
 } mme_metric_type_local_t;
 
 int mme_metrics_init_inst_local(void);
 int mme_metrics_free_inst_local(void);
+void mme_metrics_init_local(void);
 
 void mme_metrics_connected_enb_inc(char *ip_address);
 void mme_metrics_connected_enb_dec(char *ip_address);
+
+void mme_metrics_connected_enb_id_inc(mme_metric_type_local_t t, char* ip_address, char* cell_id);
+void mme_metrics_connected_enb_id_dec(mme_metric_type_local_t t, char* ip_address, char* cell_id);
 
 void mme_metrics_init(void);
 void mme_metrics_final(void);

--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -3432,7 +3432,11 @@ void mme_sess_remove(mme_sess_t *sess)
 
     ogs_assert(sess->session);
     ogs_assert(sess->session->name);
-    if (!strcmp("sos", sess->session->name)) {
+
+    if ((NULL == sess->session) ||
+        (NULL == sess->session->name)) {
+        ogs_error("Session information was NULL, could not decrement MME_METR_GLOB_GAUGE_EMERGENCY_BEARERS gauge");
+    } else if (!strcmp("sos", sess->session->name)) {
         mme_metrics_inst_global_dec(MME_METR_GLOB_GAUGE_EMERGENCY_BEARERS);
     }
 

--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -2274,10 +2274,12 @@ int mme_enb_remove(mme_enb_t *enb)
      * S1-Reset Ack buffer is not cleared at this point.
      * ogs_sctp_flush_and_destroy will clear this buffer
      */
-
     char buf[OGS_ADDRSTRLEN];
     OGS_ADDR(enb->sctp.addr, buf);
     mme_metrics_connected_enb_dec(buf);
+    char cell_id[16] = ""; // todo give this a real number
+    sprintf(cell_id, "%u", enb->enb_id);
+    mme_metrics_connected_enb_id_dec(MME_METR_LOCAL_GAUGE_ENB_ID, buf, cell_id);
 
     ogs_sctp_flush_and_destroy(&enb->sctp);
 

--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -3430,12 +3430,9 @@ void mme_sess_remove(mme_sess_t *sess)
     mme_ue = sess->mme_ue;
     ogs_assert(mme_ue);
 
-    ogs_assert(sess->session);
-    ogs_assert(sess->session->name);
-
     if ((NULL == sess->session) ||
         (NULL == sess->session->name)) {
-        ogs_error("Session information was NULL, could not decrement MME_METR_GLOB_GAUGE_EMERGENCY_BEARERS gauge");
+        ogs_error("Session information was NULL, could not check if we needed to decrement MME_METR_GLOB_GAUGE_EMERGENCY_BEARERS gauge");
     } else if (!strcmp("sos", sess->session->name)) {
         mme_metrics_inst_global_dec(MME_METR_GLOB_GAUGE_EMERGENCY_BEARERS);
     }

--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -3430,6 +3430,12 @@ void mme_sess_remove(mme_sess_t *sess)
     mme_ue = sess->mme_ue;
     ogs_assert(mme_ue);
 
+    ogs_assert(sess->session);
+    ogs_assert(sess->session->name);
+    if (!strcmp("sos", sess->session->name)) {
+        mme_metrics_inst_global_dec(MME_METR_GLOB_GAUGE_EMERGENCY_BEARERS);
+    }
+
     ogs_list_remove(&mme_ue->sess_list, sess);
 
     mme_bearer_remove_all(sess);

--- a/src/mme/s1ap-handler.c
+++ b/src/mme/s1ap-handler.c
@@ -193,6 +193,12 @@ void s1ap_handle_s1_setup_request(mme_enb_t *enb, ogs_s1ap_message_t *message)
         return;
     }
 
+    char ip[OGS_ADDRSTRLEN];
+    OGS_ADDR(enb->sctp.addr, ip);
+    char cell_id[16] = ""; // todo give this a real number
+    sprintf(cell_id, "%u", enb_id);
+    mme_metrics_connected_enb_id_inc(MME_METR_LOCAL_GAUGE_ENB_ID, ip, cell_id);
+
     enb->state.s1_setup_success = true;
     r = s1ap_send_s1_setup_response(enb);
     ogs_expect(r == OGS_OK);


### PR DESCRIPTION
This has the gauge for apn "sos" sessions and the cell id (eNB-ID) from id-Global-ENB-ID ie in s1 setup