### PR TITLE
218: charging id now included in usage logging reports

### DIFF
--- a/lib/pfcp/usage_logger.c
+++ b/lib/pfcp/usage_logger.c
@@ -41,7 +41,7 @@ bool log_usage_data(UsageLoggerState *state, time_t current_epoch_sec, UsageLogg
                 "%li,"   /* epoch */
                 "%s,"    /* imsi */
                 "%s,"    /* event */
-                "%s,"    /* charging_id */
+                "%u,"    /* charging_id */
                 "%s,"    /* msisdn */
                 "%s,"    /* ue_imei */
                 "%s,"    /* timezone_raw */

--- a/lib/pfcp/usage_logger.h
+++ b/lib/pfcp/usage_logger.h
@@ -39,8 +39,7 @@ enum
     TIMEZONE_RAW_STR_MAX_LEN = 16,
     EVENT_STR_MAX_LEN = 32,
     IP_STR_MAX_LEN = 64,
-    LOG_DIR_STR_MAX_LEN = 64,
-    PLACEHOLDER_STR_MAX_LEN = 32,
+    LOG_DIR_STR_MAX_LEN = 64
 };
 
 typedef struct
@@ -52,7 +51,7 @@ typedef struct
     uint64_t octets_out;
 
     char event[EVENT_STR_MAX_LEN];
-    char charging_id[PLACEHOLDER_STR_MAX_LEN];
+    uint32_t charging_id;
     char msisdn_bcd[MSISDN_BCD_STR_MAX_LEN];
     char imeisv_bcd[IMEISV_BCD_STR_MAX_LEN];
     char timezone_raw[TIMEZONE_RAW_STR_MAX_LEN];

--- a/src/sgwc/context.c
+++ b/src/sgwc/context.c
@@ -697,6 +697,28 @@ sgwc_bearer_t *sgwc_bearer_find_by_ue_ebi(sgwc_ue_t *sgwc_ue, uint8_t ebi)
     return NULL;
 }
 
+sgwc_bearer_t *sgwc_bearer_find_by_sess_urr_id(sgwc_sess_t *sess, uint32_t urr_id)
+{
+    sgwc_bearer_t *bearer = NULL;
+    sgwc_tunnel_t *tunnel = NULL;
+
+    ogs_assert(sess);
+    ogs_list_for_each(&sess->bearer_list, bearer) {
+        ogs_list_for_each(&bearer->tunnel_list, tunnel) {
+            ogs_assert(tunnel->pdr);
+            for (int i = 0; i < tunnel->pdr->num_of_urr; ++i) {
+                ogs_pfcp_urr_t *urr = tunnel->pdr->urr[i];
+
+                if (urr->id == urr_id) {
+                    return bearer;
+                }
+            }
+        }
+    }
+    
+    return NULL;
+}
+
 sgwc_bearer_t *sgwc_default_bearer_in_sess(sgwc_sess_t *sess)
 {
     ogs_assert(sess);

--- a/src/sgwc/context.h
+++ b/src/sgwc/context.h
@@ -134,6 +134,8 @@ typedef struct sgwc_bearer_s {
 
     /* Used to deactivate unused bearers */
     ogs_timer_t* timer_bearer_deactivation;
+
+    uint32_t charging_id;
 } sgwc_bearer_t;
 
 typedef struct sgwc_tunnel_s {
@@ -198,6 +200,8 @@ sgwc_bearer_t *sgwc_bearer_find_by_sess_ebi(
                                 sgwc_sess_t *sess, uint8_t ebi);
 sgwc_bearer_t *sgwc_bearer_find_by_ue_ebi(
                                 sgwc_ue_t *sgwc_ue, uint8_t ebi);
+sgwc_bearer_t *sgwc_bearer_find_by_sess_urr_id(
+                                sgwc_sess_t *sess, uint32_t urr_id);
 sgwc_bearer_t *sgwc_default_bearer_in_sess(sgwc_sess_t *sess);
 sgwc_bearer_t *sgwc_bearer_cycle(sgwc_bearer_t *bearer);
 

--- a/src/sgwc/s5c-handler.c
+++ b/src/sgwc/s5c-handler.c
@@ -272,6 +272,11 @@ void sgwc_s5c_handle_create_session_response(
             ogs_pfcp_ip_to_outer_header_creation(&ul_tunnel->remote_ip,
                 &far->outer_header_creation, &far->outer_header_creation_len));
         far->outer_header_creation.teid = ul_tunnel->remote_teid;
+
+        /* Set the charging id to be used for CDR (See log_start_usage_reports in sxa-handler.c) */
+        if (rsp->bearer_contexts_created[i].charging_id.presence) {
+            bearer->charging_id = rsp->bearer_contexts_created[i].charging_id.u32;
+        }
     }
 
     /* Receive Control Plane(UL) : PGW-S5C */


### PR DESCRIPTION
Tested to work in sim.

**session_start** events will always have a charging id of 0 as they are created before the CSResp is received.

If the CSResp does not return a charging id, the default charging id in the logs will be 0. This value will be seen in **session_update** and **session_end** events.